### PR TITLE
Support python3 and python2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 gurobi.log
 .DS_Store
 .ipynb_checkpoints
+venv
+build
+dist
+*.egg-info
+.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 dist
 *.egg-info
 .pytest_cache
+venv*

--- a/pympc/control/controllers.py
+++ b/pympc/control/controllers.py
@@ -525,7 +525,7 @@ class HybridModelPredictiveController(object):
         |bigM[2][1]          0 bigM[2][3] ...|
         |bigM[3][1] bigM[3][2]          0 ...|
         |       ...        ...        ... ...|
-        
+
         Arguments
         ----------
         bigM : list of lists of numpy.ndarray
@@ -655,7 +655,7 @@ class HybridModelPredictiveController(object):
         mode_sequence = []
         for d in d_list:
             mode_sequence.append(np.where(d > .5)[0][0])
-            
+
         return u_list, x_list, mode_sequence, sol['min']
 
     def feedback(self, x):

--- a/pympc/dynamics/discretization_methods.py
+++ b/pympc/dynamics/discretization_methods.py
@@ -56,7 +56,7 @@ def zero_order_hold(A, B, c, h):
     c_d = B_d := int_0^h exp(A (h - t)) dt c.
     I holds
          |A B c|      |A_d B_d c_d|
-    exp (|0 0 0| h) = |0   I   0  | 
+    exp (|0 0 0| h) = |0   I   0  |
          |0 0 0|      |0   0   1  |
     where both the matrices are square.
     Proof: apply the definition of exponential and note that int_0^h exp(A (h - t)) dt = sum_{k=1}^inf A^(k-1) h^k/k!.

--- a/pympc/geometry/polyhedron.py
+++ b/pympc/geometry/polyhedron.py
@@ -1,4 +1,5 @@
 # external imports
+from six.moves import range  # behaves like xrange on python2, range on python3
 import numpy as np
 from copy import copy
 from scipy.spatial import HalfspaceIntersection, ConvexHull
@@ -375,7 +376,7 @@ class Polyhedron(object):
             f = self.b
 
         # initialize list of non-redundant facets
-        minimal_facets = range(E.shape[0])
+        minimal_facets = list(range(E.shape[0]))
 
         # check each facet
         for i in range(E.shape[0]):
@@ -737,7 +738,7 @@ class Polyhedron(object):
 
         # check full dimensionality
         tol = 1.e-7
-        if self.radius < tol:
+        if self.radius is None or self.radius < tol:
             return None
 
         # check boundedness

--- a/pympc/geometry/polyhedron.py
+++ b/pympc/geometry/polyhedron.py
@@ -181,7 +181,7 @@ class Polyhedron(object):
         S : numpy.ndarray
             Selection matrix.
         """
-        
+
         # if indices is None select all the rows
         n = self.A.shape[1]
         if indices is None:
@@ -573,7 +573,7 @@ class Polyhedron(object):
         P1 = Polyhedron(A1, b1)
         A2 = np.vstack((P2.A, P2.C, -P2.C))
         b2 = np.vstack((P2.b, P2.d, -P2.d))
-        
+
         # check inclusion, one facet per time
         included = True
         lp = LinearProgram(P1)
@@ -721,11 +721,11 @@ class Polyhedron(object):
 
     @property
     def vertices(self):
-    	"""
-    	Returns the set of vertices of the polyhdron.
-    	It assumes the polyhedron to be bounded (i.e. to be a polytope) and full dimensional (equality constraints are allowed but inequalities cannot make the polytope lower dimensional).
+        """
+        Returns the set of vertices of the polyhdron.
+        It assumes the polyhedron to be bounded (i.e. to be a polytope) and full dimensional (equality constraints are allowed but inequalities cannot make the polytope lower dimensional).
 
-    	Returns
+        Returns
         ----------
         vertices : list of numpy.ndarray
             List of the vertices of the bounded polyhedron (None if the polyhedron is unbounded or empty).
@@ -735,9 +735,9 @@ class Polyhedron(object):
         if self._vertices is not None:
             return self._vertices
 
-    	# check full dimensionality
+        # check full dimensionality
         tol = 1.e-7
-    	if self.radius < tol:
+        if self.radius < tol:
             return None
 
         # check boundedness
@@ -763,17 +763,17 @@ class Polyhedron(object):
 
         # call qhull through scipy
         else:
-	    	halfspaces = np.hstack((A, -b))
-	    	polyhedron = HalfspaceIntersection(halfspaces, center.flatten())
-	    	V = polyhedron.intersections
-	    	self._vertices = [V[i:i+1,:].T for i in range(V.shape[0])]
+            halfspaces = np.hstack((A, -b))
+            polyhedron = HalfspaceIntersection(halfspaces, center.flatten())
+            V = polyhedron.intersections
+            self._vertices = [V[i:i+1,:].T for i in range(V.shape[0])]
 
-	    # go back to the original coordinates in case of equalities
+        # go back to the original coordinates in case of equalities
         if self.C.shape[0] > 0:
             r = np.linalg.inv(self.C.dot(R)).dot(self.d)
             self._vertices = [T.dot(np.vstack((v, r))) for v in self._vertices]
 
-    	return self._vertices
+        return self._vertices
 
     def project_to(self, residual_dimensions):
         """
@@ -802,16 +802,16 @@ class Polyhedron(object):
         A, b, vertices = convex_hull_method(self.A, self.b, residual_dimensions)
         proj = Polyhedron(A, b)
         proj._vertices = vertices
-        
+
         return proj
 
     @staticmethod
     def from_convex_hull(points):
         """
-    	Instantiates the polyhderon given from the conve hull of the given set of points.
-    	It assumes the polyhedron to be bounded.
+        Instantiates the polyhderon given from the conve hull of the given set of points.
+        It assumes the polyhedron to be bounded.
 
-    	Arguments
+        Arguments
         ----------
         points : list of numpy.ndarray
             List of points.
@@ -847,8 +847,8 @@ class Polyhedron(object):
 
         # extract vertices components
         if self.vertices is None:
-        	print('Cannot plot unbounded or empty polyhedra.')
-        	return
+            print('Cannot plot unbounded or empty polyhedra.')
+            return
 
         # call qhull thorugh scipy for the convex hull (needed to order the vertices in counterclockwise order)
         vertices = np.hstack(self.vertices).T[:,residual_dimensions]
@@ -886,7 +886,7 @@ def convex_hull_method(A, b, resiudal_dimensions):
         Right-hand side of the inequalities describing the higher dimensional polytope.
     residual_dimensions : list of int
         Indices of the dimensions onto which the polytope has to be projected.
-    
+
     Returns
     ----------
     E : numpy.ndarray
@@ -943,7 +943,7 @@ def _get_two_vertices(A, b, n):
         Right-hand side of the inequalities describing the higher dimensional polytope.
     n : int
         Dimensionality of the space onto which the polytope has to be projected.
-    
+
     Returns
     ----------
     vertices : list of numpy.ndarray
@@ -989,7 +989,7 @@ def _get_inner_simplex(A, b, vertices, tol=1.e-7):
 
     # initialize LPs
     n = vertices[0].shape[0]
-    
+
     # expand increasing at every iteration the dimension of the space
     X = Polyhedron(A, b)
     lp = LinearProgram(X)

--- a/pympc/optimization/gurobi.py
+++ b/pympc/optimization/gurobi.py
@@ -90,7 +90,7 @@ def quadratic_program(H, f, A, b, C=None, d=None, **kwargs):
         multiplier_equality : numpy.ndarray
             Lagrange multipliers for the equality constraints (None if the problem is unfeasible or without equality constraints).
     """
-    
+
     # get model
     model = _build_model(H=H, f=f, A=A, b=b, C=C, d=d)
 

--- a/pympc/optimization/parametric_programs.py
+++ b/pympc/optimization/parametric_programs.py
@@ -54,7 +54,7 @@ class MultiParametricQuadraticProgram(object):
         The inactive (primal and dual) constraints define the region of space where the given active set is optimal
         Aui u + Axi x < bi, (primal feasibility),
         pa > 0,             (dual feasibility).
-        
+
 
         Arguments
         ----------
@@ -182,7 +182,7 @@ class MultiParametricQuadraticProgram(object):
         It assumes that the facet-to-facet property holds (i.e. each facet of a critical region is shared with another single critical region).
         The following is a simple home-made algorithm.
         For every critical region, it looks at its non-redundat inequalities and guesses the active set beyond them.
-        It then solves the KKTs for the given active set and check if the guess was right, if not it solves a QP to get the right active set and solves the KKTs again. 
+        It then solves the KKTs for the given active set and check if the guess was right, if not it solves a QP to get the right active set and solves the KKTs again.
 
         Arguments
         ----------
@@ -204,7 +204,7 @@ class MultiParametricQuadraticProgram(object):
         x_buffer = [(x, active_set_guess)]
         crs_found = []
 
-        # loop until the are no points left 
+        # loop until the are no points left
         while len(x_buffer) > 0:
 
             # get critical region for the first point in the buffer
@@ -345,7 +345,7 @@ class CriticalRegion(object):
             )
 
         return facet.center
-        
+
     def u(self, x):
         """
         Numeric value of the primal optimizer at the point x.

--- a/pympc/optimization/pnnls.py
+++ b/pympc/optimization/pnnls.py
@@ -52,7 +52,7 @@ def linear_program(f, A, b, C=None, d=None, tol=1.e-7):
     A' y = f,        y >= 0, dual feasibility,
     where y are the Lagrange multipliers and s are slack variables for the residual of primal feasibility.
     (Each equality constraint is reformulated as two inequalities.)
-    
+
     Arguments
     ----------
     f : numpy.ndarray

--- a/pympc/test/test_control/test_controllers.py
+++ b/pympc/test/test_control/test_controllers.py
@@ -77,7 +77,7 @@ class testModelPredictiveController(unittest.TestCase):
                     self.assertAlmostEqual(V_mpc, V_lqr)
                     for t in range(N):
                         np.testing.assert_array_almost_equal(u_mpc[t], u_lqr[t])
-                
+
                 # if x is outside mcais lqr > mpc
                 elif V_mpc is not None:
                     self.assertTrue(V_mpc > V_lqr)

--- a/pympc/test/test_dynamics/test_discrete_time_systems.py
+++ b/pympc/test/test_dynamics/test_discrete_time_systems.py
@@ -94,12 +94,12 @@ class TestLinearSystem(unittest.TestCase):
             max_iter = 1000
             t = 0
             while not np.isclose(infinite_horizon_V, finite_horizon_V):
-            	finite_horizon_V += .5*(x0.T.dot(Q).dot(x0) + (K.dot(x0)).T.dot(R).dot(K).dot(x0))
-            	x0 = A_cl.dot(x0)
-            	t += 1
-            	if t == max_iter:
-            		self.assertTrue(False)
-            	
+                finite_horizon_V += .5*(x0.T.dot(Q).dot(x0) + (K.dot(x0)).T.dot(R).dot(K).dot(x0))
+                x0 = A_cl.dot(x0)
+                t += 1
+                if t == max_iter:
+                    self.assertTrue(False)
+
     def test_mcais(self):
         """
         Tests only if the function macais() il called correctly.
@@ -284,7 +284,7 @@ class TestPieceWiseAffineSystem(unittest.TestCase):
                 u_list.append(u_t)
                 x_tp1 = A_t.dot(x_t) + B_t.dot(u_t) + c_t
                 x = np.vstack((x, x_tp1))
-                
+
                 # create a domain that contains x and u (it has to be super-tight so that the pwa system is well posed!)
                 D = Polyhedron.from_bounds(
                     np.vstack((x_t/1.01, u_t/1.01)),

--- a/pympc/test/test_geometry/test_polyhedron.py
+++ b/pympc/test/test_geometry/test_polyhedron.py
@@ -13,17 +13,17 @@ class TestPolyhedron(unittest.TestCase):
 
     def test_initialization(self):
 
-    	# 1 or 2d right hand sides
-    	A = np.eye(3)
-    	C = np.eye(2)
-    	b = np.ones((3,1))
-    	b_1d = np.ones(3)
-    	d = np.ones((2,1))
-    	d_1d = np.ones(2)
-    	p = Polyhedron(A, b, C, d)
-    	p_1d = Polyhedron(A, b_1d, C, d_1d)
-    	np.testing.assert_array_equal(p.b, p_1d.b)
-    	np.testing.assert_array_equal(p.d, p_1d.d)
+        # 1 or 2d right hand sides
+        A = np.eye(3)
+        C = np.eye(2)
+        b = np.ones((3,1))
+        b_1d = np.ones(3)
+        d = np.ones((2,1))
+        d_1d = np.ones(2)
+        p = Polyhedron(A, b, C, d)
+        p_1d = Polyhedron(A, b_1d, C, d_1d)
+        np.testing.assert_array_equal(p.b, p_1d.b)
+        np.testing.assert_array_equal(p.d, p_1d.d)
 
         # wrong initializations
         self.assertRaises(ValueError, Polyhedron, A, b, C)
@@ -32,7 +32,7 @@ class TestPolyhedron(unittest.TestCase):
 
     def test_add_functions(self):
 
-    	# add inequalities
+        # add inequalities
         A = np.eye(2)
         b = np.ones(2)
         p = Polyhedron(A, b)
@@ -48,7 +48,7 @@ class TestPolyhedron(unittest.TestCase):
         c = np.ones(2)
         self.assertRaises(ValueError, p.add_inequality, A, c)
 
-    	# add equalities
+        # add equalities
         p.add_equality(A, b)
         self.assertTrue(same_rows(
             np.hstack((A, b)),
@@ -187,7 +187,7 @@ class TestPolyhedron(unittest.TestCase):
             np.hstack((p.C, p.d)),
             normalize=False
             ))
-        
+
     def test_remove_equalities(self):
 
         # contruct polyhedron
@@ -240,7 +240,7 @@ class TestPolyhedron(unittest.TestCase):
         p = Polyhedron(A,b)
         mf = set(p.minimal_facets())
         self.assertTrue(mf == set([1,2,0]) or mf == set([1,2,5]))
-        
+
         # add nasty redundant inequality
         A = np.zeros((1,2))
         b = np.ones((1,1))

--- a/pympc/test/test_geometry/test_utils.py
+++ b/pympc/test/test_geometry/test_utils.py
@@ -1,4 +1,5 @@
 # external imports
+from six.moves import range  # behaves like xrange on python2, range on python3
 import unittest
 import numpy as np
 from random import shuffle
@@ -43,7 +44,7 @@ class TestUtils(unittest.TestCase):
         # all linearly independent
         A = np.eye(3)
         li_rows = linearly_independent_rows(A)
-        self.assertTrue(li_rows == range(3))
+        self.assertTrue(li_rows == list(range(3)))
 
     def test_plane_through_points(self):
 
@@ -78,7 +79,7 @@ class TestUtils(unittest.TestCase):
             self.assertTrue(same_rows(A, B))
 
             # check without scaling factors
-            B_order = range(n)
+            B_order = list(range(n))
             shuffle(B_order)
             B = A[B_order, :]
             self.assertTrue(same_rows(A, B, normalize=False))
@@ -99,21 +100,21 @@ class TestUtils(unittest.TestCase):
 
             # check equal lists
             v_list = [np.random.rand(n, 1) for j in range(N)]
-            u_order = range(N)
+            u_order = list(range(N))
             shuffle(u_order)
             u_list = [v_list[j] for j in u_order]
             self.assertTrue(same_vectors(v_list, u_list))
 
         # wrong size (only 2d arrays allowed)
         v_list = [np.random.rand(n) for j in range(N)]
-        u_order = range(N)
+        u_order = list(range(N))
         shuffle(u_order)
         u_list = [v_list[j] for j in u_order]
         self.assertRaises(ValueError, same_vectors, v_list, u_list)
 
         # wrong size (matrices not allowed)
         v_list = [np.random.rand(n,3) for j in range(N)]
-        u_order = range(N)
+        u_order = list(range(N))
         shuffle(u_order)
         u_list = [v_list[j] for j in u_order]
         self.assertRaises(ValueError, same_vectors, v_list, u_list)

--- a/pympc/test/test_optimization/test_convex_programs.py
+++ b/pympc/test/test_optimization/test_convex_programs.py
@@ -11,7 +11,7 @@ class TestLinearProgram(unittest.TestCase):
 
     def test_solve(self):
 
-    	# trivial LP with only inequalities
+        # trivial LP with only inequalities
         A = -np.eye(2)
         b = np.zeros((2, 1))
         X = Polyhedron(A, b)
@@ -66,17 +66,17 @@ class TestLinearProgram(unittest.TestCase):
 
     def test_solve_min_norm(self):
 
-    	# simple 2d problem
-    	x0_min = np.zeros((1,1))
-    	X = Polyhedron.from_lower_bound(x0_min, [0], 2)
-    	C = - np.array(([[1., 10.]]))
-    	d = - np.array(([[10.]]))
-    	X.add_equality(C, d)
-    	lp = LinearProgram(X)
+        # simple 2d problem
+        x0_min = np.zeros((1,1))
+        X = Polyhedron.from_lower_bound(x0_min, [0], 2)
+        C = - np.array(([[1., 10.]]))
+        d = - np.array(([[10.]]))
+        X.add_equality(C, d)
+        lp = LinearProgram(X)
 
-    	# norm one, identity weight
-    	sol_one = lp.solve_min_norm_one()
-    	self.assertAlmostEqual(
+        # norm one, identity weight
+        sol_one = lp.solve_min_norm_one()
+        self.assertAlmostEqual(
             sol_one['min'],
             1.
             )
@@ -98,8 +98,8 @@ class TestLinearProgram(unittest.TestCase):
             )
 
         # norm inf, identity weight
-    	sol_inf = lp.solve_min_norm_inf()
-    	self.assertAlmostEqual(
+        sol_inf = lp.solve_min_norm_inf()
+        self.assertAlmostEqual(
             sol_inf['min'],
             10./11.
             )
@@ -122,8 +122,8 @@ class TestLinearProgram(unittest.TestCase):
 
         # norm one, with weight matrix
         W = np.array([[1., 0.],[0., 11.]])
-    	sol_one = lp.solve_min_norm_one(W)
-    	self.assertAlmostEqual(
+        sol_one = lp.solve_min_norm_one(W)
+        self.assertAlmostEqual(
             sol_one['min'],
             10.
             )
@@ -145,8 +145,8 @@ class TestLinearProgram(unittest.TestCase):
             )
 
         # norm inf, with weight matrix
-    	sol_inf = lp.solve_min_norm_inf(W)
-    	self.assertAlmostEqual(
+        sol_inf = lp.solve_min_norm_inf(W)
+        self.assertAlmostEqual(
             sol_inf['min'],
             110./21.
             )

--- a/pympc/test/test_optimization/test_parametric_programs.py
+++ b/pympc/test/test_optimization/test_parametric_programs.py
@@ -54,7 +54,7 @@ class TestMultiParametricQuadraticProgram(unittest.TestCase):
         # implicit solve given point
         sol = mpqp.solve(np.array([[1.5]]))
         self.assertAlmostEqual(sol['min'], .125)
-        self.assertAlmostEqual(sol['argmin'], .5)
+        self.assertTrue(np.allclose(sol['argmin'], 0.5))
         self.assertEqual(sol['active_set'], [1])
 
         # solve

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='pympc',
           'computational geometry'
           ],
       install_requires=[
+          'six',
           'numpy',
           'scipy',
           'matplotlib'


### PR DESCRIPTION
Hi @TobiaMarcucci! 

I was just looking through the code, and I thought I'd try it out on python3.5. I just had to make a few changes to get all the tests passing both in python2.7 and python3.5. The changes are:

* You had a mix of tabs and spaces for indentation in a few files. That's not allowed in python 3, so I changed them all to spaces
* In python3, `range()` is lazy (it only generates numbers when you ask for them), so you can't shuffle a range or set its elements. To get a list of numbers, you do `list(range(10))`. I've brought in the `six` module which provides a version of `range()` that does the right thing in python2 and python3. 
* There was one place (line 741 of polyhedron.py) where you had:

```python
if self.radius < tol:
    ....
```

but `self.radius` could occasionally be `None`. In python2, `None < x` is true for any number `x`, but in python3 it's an error. I've changed the code to `if self.radius is None or self.radius < tol` but I wonder if the fact that `self.radius` is sometimes None might be a bug? Removing `None < x` in python3 was, in fact, explicitly done to avoid subtle bugs when variables were accidentally None. 

